### PR TITLE
Paso 7: Usar los datos de cada personaje en el listado y arreglar el estado desconocido de personaje

### DIFF
--- a/src/components/CharacterCard/CharacterCard.tsx
+++ b/src/components/CharacterCard/CharacterCard.tsx
@@ -11,21 +11,41 @@ import {
   StatusIndicator
 } from './styles'
 
-const CharacterCard: FC = () => (
+const CharacterStatusName = {
+  [CharacterStatus.Alive]: 'Vivo',
+  [CharacterStatus.Dead]: 'Muerto',
+  [CharacterStatus.Unknown]: 'Desconocido'
+}
+
+type Props = {
+  name: string
+  image: string
+  status: CharacterStatus
+  species: string
+  lastKnownLocation: string
+  firstEpisode: string
+}
+
+const CharacterCard: FC<Props> = ({
+  name,
+  image,
+  status,
+  species,
+  lastKnownLocation,
+  firstEpisode
+}) => (
   <Card>
     <ImageWrapper>
-      <Image
-        src='https://rickandmortyapi.com/api/character/avatar/2.jpeg'
-        alt='Morty Smith'
-      />
+      <Image src={image} alt={name} />
     </ImageWrapper>
     <ContentWrapper>
       <Section>
         <Typography variant='heading' color='white' size='big'>
-          Morty Smith
+          {name}
         </Typography>
         <Typography color='white' size='small'>
-          <StatusIndicator status={CharacterStatus.Alive} /> Alive - Human
+          <StatusIndicator status={status} /> {CharacterStatusName[status]} -{' '}
+          {species}
         </Typography>
       </Section>
       <Section>
@@ -33,7 +53,7 @@ const CharacterCard: FC = () => (
           Última ubicación conocida:
         </Typography>
         <Typography color='white' size='medium'>
-          Story Train
+          {lastKnownLocation}
         </Typography>
       </Section>
       <Section>
@@ -41,7 +61,7 @@ const CharacterCard: FC = () => (
           Primer episodio donde aparece:
         </Typography>
         <Typography color='white' size='medium'>
-          Never Ricking Morty
+          {firstEpisode}
         </Typography>
       </Section>
     </ContentWrapper>

--- a/src/components/CharactersList/CharactersList.tsx
+++ b/src/components/CharactersList/CharactersList.tsx
@@ -1,17 +1,27 @@
 import { FC } from 'react'
+import { CharacterFragment } from '../../graphql'
+import { CharacterStatus } from '../../types'
 
 import { CharacterCard } from '../CharacterCard'
 import { List, ListWrapper } from './styles'
 
 type Props = {
-  characters: any[]
+  characters: CharacterFragment[]
 }
 
 const CharactersList: FC<Props> = ({ characters }) => (
   <ListWrapper>
     <List>
-      {characters.map((_, index) => (
-        <CharacterCard key={index} />
+      {characters.map((character) => (
+        <CharacterCard
+          key={character.id}
+          name={character.name!}
+          image={character.image!}
+          status={character.status as CharacterStatus}
+          species={character.species!}
+          lastKnownLocation={character.location!.name!}
+          firstEpisode={character.episode![0]?.name!}
+        />
       ))}
     </List>
   </ListWrapper>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,5 @@
 export enum CharacterStatus {
   Alive = 'Alive',
   Dead = 'Dead',
-  Unknown = 'Unknown'
+  Unknown = 'unknown'
 }


### PR DESCRIPTION
Este último paso vamos a modificar nuestra tarjeta de personajes para mostrar los datos correspondientes:
- `name`
- `image`
- `species`
- `status`
- `lastKnownLocation`
- `firstEpisode`

Vamos a traducir el estado del persona usando otro enum dentro del mismo archivo de `<CharacterCard>`.

Y en el `<CharactersList>` vamos a cambiar el tipo del listado de `any[]` a `CharacterFragment[]`.

Para finalizar veremos que tenemos un bug en nuestro programa: los personajes que tienen un estado desconocido no muestran su indicador ni el texto.

Esto es porque el texto nos llega en minúscula.

Para arreglarlo, podemos cambiar el `enum` para que el valor de `Unknown` sea `unknown` en minúsculas y sea igual al valor que nos viene de la API.

Con esto nuestra app quedará terminada.

![image](https://user-images.githubusercontent.com/1213542/115487353-e8088580-a22e-11eb-80b9-c33279565da6.png)